### PR TITLE
ensure HTTPSession._finish is called for all requests

### DIFF
--- a/http/_http_parser.pony
+++ b/http/_http_parser.pony
@@ -106,6 +106,7 @@ class _HTTPParser
     let payload = _payload = Payload._empty(_client)
     _session._deliver(consume payload)
     if not body_follows then
+      _session._finish()
       _restart()
     end
 


### PR DESCRIPTION
from the parser. 

Otherwise it is impossible to tell in a generic setup (like a benchmark) when a request has been fully parsed and sent upstream to the application.
Making sure that `HTTPSession._finish()` is called for every request, makes such situations much easier to deal with.