### PR TITLE
http/http_parser: naively re-work error handling

### DIFF
--- a/http/_client_conn_handler.pony
+++ b/http/_client_conn_handler.pony
@@ -47,11 +47,9 @@ class _ClientConnHandler is TCPConnectionNotify
     _buffer.append(consume data)
 
     // Let the parser take a look at what has been received.
-    try
-      _parser.parse(_buffer)?
-    else
-      // Any syntax errors will terminate the connection.
-      conn.close()
+    match _parser.parse(_buffer)
+    // Any syntax errors will terminate the connection.
+    | ParseError => conn.close()
     end
     true
 

--- a/http/_server_conn_handler.pony
+++ b/http/_server_conn_handler.pony
@@ -63,12 +63,10 @@ class _ServerConnHandler is TCPConnectionNotify
 
     match _parser
     | let b: HTTPParser =>
-      try
-        // Let the parser take a look at what has been received.
-        b.parse(_buffer)?
-      else
-        // Any syntax errors will terminate the connection.
-        conn.close()
+      // Let the parser take a look at what has been received.
+      match b.parse(_buffer)
+      // Any syntax errors will terminate the connection.
+      | ParseError => conn.close()
       end
     end
     true

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -604,10 +604,8 @@ class iso _HTTPParserNoBodyTest is UnitTest
     h.expect_action("_deliver")
     let reader: Reader = Reader
     reader.append(payload)
-    try
-      parser.parse(reader)?
-    else
-      h.fail("parser failed to parse request")
+    match parser.parse(reader)
+    | ParseError => h.fail("parser failed to parse request")
     end
 
 class iso _HTTPParserOneshotBodyTest is UnitTest
@@ -650,8 +648,6 @@ class iso _HTTPParserOneshotBodyTest is UnitTest
     h.expect_action("_deliver")
     let reader: Reader = Reader
     reader.append(payload)
-    try
-      parser.parse(reader)?
-    else
-      h.fail("parser failed to parse request")
+    match parser.parse(reader)
+    | ParseError => h.fail("parser failed to parse request")
     end

--- a/http/bench/main.pony
+++ b/http/bench/main.pony
@@ -79,9 +79,8 @@ class _ParseRequestBenchmark
     while data_iter.has_next() do
       let chunk = data_iter.next()?
       _reader.append(chunk)
-      try
-        _parser.parse(_reader)?
-      else
+      match _parser.parse(_reader)
+      | ParseError =>
         Debug("parsing failed.")
         if not data_iter.has_next() then
           c.fail()


### PR DESCRIPTION
This is my rather naive attempt at #2.

Turns out the benchmark results vary quite a bit, from 

```
Benchmark                                   mean            median   deviation  iterations
request/simple                           5455 ns           5379 ns      ±3.00%         100
request/form-submission                  9139 ns           9054 ns      ±3.93%         100
request/form-submission/split           12116 ns          11832 ns      ±6.79%         100
request/multipart-file-upload           67980 ns          68630 ns     ±55.28%         100
request/chunked                          8147 ns           7595 ns     ±14.50%         100
```
which making things a lot worse for the simple request;

to

```
Benchmark                                   mean            median   deviation  iterations
request/simple                           2078 ns           2049 ns      ±3.58%         100
request/form-submission                  9684 ns           9614 ns      ±6.75%         100
request/form-submission/split           12240 ns          12061 ns      ±5.09%         100
request/multipart-file-upload           40596 ns          43035 ns     ±32.65%         100
request/chunked                          7959 ns           7657 ns      ±8.08%         100
```

which doesn't look so bad.

For comparison, running `make bench` with `master` on this machine got me
```
Benchmark                                   mean            median   deviation  iterations
request/simple                           2191 ns           2159 ns      ±6.98%         100
request/form-submission                 10201 ns          10026 ns     ±13.37%         100
request/form-submission/split           13144 ns          13073 ns      ±6.25%         100
request/multipart-file-upload           38564 ns          42741 ns     ±35.76%         100
request/chunked                          9232 ns           9287 ns      ±2.05%         100
```