### PR TITLE
README: it's been removed from stdlib in 0.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It contains both an HTTP client to issue HTTP requests against HTTP servers, and
 an HTTP server. It also contains a library for handling and parsing URLs.
 
 It was removed from the stdlib with [0.24.0](https://github.com/ponylang/ponyc/releases/tag/0.24.0) as a result of
-[RFC 55](https://github.com/ponylang/rfcs/blob/master/text/0055-remove-http-server-from-stdlib.md).
+[RFC 55](https://github.com/ponylang/rfcs/blob/master/text/0055-remove-http-server-from-stdlib.md). See also [the announcement blog post](https://www.ponylang.io/blog/2018/06/0.24.0-released/).
 The Pony Team decided to remove it from the stdlib as is did not meet their quality standards.
 Given the familiarity of most people with HTTP and thus the attention this library gets,
 it was considered wiser to remove it from the stdlib and give it a new home as a separate

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the Pony HTTP/1 library from the standard library, formerly known as `ne
 It contains both an HTTP client to issue HTTP requests against HTTP servers, and
 an HTTP server. It also contains a library for handling and parsing URLs.
 
-It will be removed from the stdlib with one of the next minor releases as a result of
+It was removed from the stdlib with [0.24.0](https://github.com/ponylang/ponyc/releases/tag/0.24.0) as a result of
 [RFC 55](https://github.com/ponylang/rfcs/blob/master/text/0055-remove-http-server-from-stdlib.md).
 The Pony Team decided to remove it from the stdlib as is did not meet their quality standards.
 Given the familiarity of most people with HTTP and thus the attention this library gets,


### PR DESCRIPTION
🤔 We could also link to the announcement blog post: https://www.ponylang.io/blog/2018/06/0.24.0-released/ -- preferences? 😃 