### PR TITLE
remove default port in 'Host:' attribute

### DIFF
--- a/http/payload.pony
+++ b/http/payload.pony
@@ -343,7 +343,11 @@ class trn Payload
       conn.write("Connection: close\r\n")
     end
 
-    conn.write("Host: " + url.host + ":" + url.port.string() + "\r\n")
+    if url.port == url.default_port() then
+      conn.write("Host: " + url.host + "\r\n")
+    else
+      conn.write("Host: " + url.host + ":"  + url.port.string() + "\r\n")
+    end
 
   fun val _write_common(conn: TCPConnection tag) =>
     """


### PR DESCRIPTION
without this commit http client can not access http://http://www.imk-tro.kit.edu/7667.php (debian apache server)