### PR TITLE
Remove request from client `_sent` queue after handling chunks

### DIFF
--- a/http/_client_connection.pony
+++ b/http/_client_connection.pony
@@ -190,8 +190,11 @@ actor _ClientConnection is HTTPSession
     _send_pending is called to detect that _unsent and _sent are emptye
     and that _conn can be disposed.
     """
-    _app_handler.finished()
-    _send_pending()
+    try
+      _sent.shift()?
+      _app_handler.finished()
+      _send_pending()
+    end
 
   be finish() =>
     """


### PR DESCRIPTION
This commit makes a change to `_ClientConnection::_finish()` that
removes the current request from the `_sent` queue when `_finish()` is
called. Currently the request is not removed from `_sent`, which means
that `_sent.size()` is never equal to `0` in `_send_pending`, which
means that the connection will never be closed because the client does
not know that it has finished handling all requests.

This change brings the behavior of `_finish` into line with the
behavior of `_deliver`, which removes the request from `_sent` before
calling `_send_pending`.

Closes #21