### PR TITLE
Add regex and net_ssl as dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - image: ponylang/ponyc:latest
     steps:
       - checkout
-      - run: make test examples
+      - run: make fetch test examples
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - image: ponylang/ponyc:latest
     steps:
       - checkout
-      - run: make fetch test examples
+      - run: make test examples
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
     docker:
       - image: ponylang/ponyc:latest
     steps:
+      - run: apt-get update
+      - run: apt-get install -y libpcre2-dev libssl-dev
       - checkout
       - run: make test examples
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /build/*
 /.coverage/
-
+.deps

--- a/bundle.json
+++ b/bundle.json
@@ -1,0 +1,12 @@
+{
+  "deps": [
+    {
+      "type": "github",
+      "repo": "ponylang/net-ssl"
+    },
+    {
+      "type": "github",
+      "repo": "ponylang/regex"
+    }
+  ]
+}

--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -3,8 +3,8 @@ use "cli"
 use "collections"
 use "encode/base64"
 use "files"
-use "http"
-use "net/ssl"
+use "../../http"
+use "net_ssl"
 
 class val Config
   let user: String
@@ -239,4 +239,3 @@ class HttpNotify is HTTPHandler
 
   fun ref failed(reason: HTTPFailureReason) =>
     _main.failed(reason)
-

--- a/examples/httpserver/httpserver.pony
+++ b/examples/httpserver/httpserver.pony
@@ -1,4 +1,4 @@
-use "http"
+use "../../http"
 
 actor Main
   """

--- a/http/_client_connection.pony
+++ b/http/_client_connection.pony
@@ -1,6 +1,6 @@
 use "collections"
 use "net"
-use "net/ssl"
+use "net_ssl"
 
 primitive _ConnConnecting
 

--- a/http/_server_listener.pony
+++ b/http/_server_listener.pony
@@ -1,5 +1,5 @@
 use "net"
-use "net/ssl"
+use "net_ssl"
 
 class _ServerListener is TCPListenNotify
   """

--- a/http/client.pony
+++ b/http/client.pony
@@ -1,6 +1,6 @@
 use "collections"
 use "net"
-use "net/ssl"
+use "net_ssl"
 
 class HTTPClient
   """
@@ -154,4 +154,3 @@ class _SessionGuard
 
     // Channel can not accept another request now.
     error
-

--- a/http/server.pony
+++ b/http/server.pony
@@ -1,6 +1,6 @@
 use "collections"
 use "net"
-use "net/ssl"
+use "net_ssl"
 
 actor HTTPServer
   """

--- a/http/test/client_error_handling.pony
+++ b/http/test/client_error_handling.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use ".."
 use "net"
-use "net/ssl"
+use "net_ssl"
 use "files"
 
 primitive ClientErrorHandlingTests is TestList

--- a/http/test/server_error_handling.pony
+++ b/http/test/server_error_handling.pony
@@ -1,7 +1,7 @@
 use ".."
 use "ponytest"
 use "net"
-use "net/ssl"
+use "net_ssl"
 use "files"
 
 primitive ServerErrorHandlingTests is TestList
@@ -78,4 +78,3 @@ class iso ServerConnectionClosedTest is UnitTest
       where host = "127.0.0.1"
     )
     h.dispose_when_done(server)
-


### PR DESCRIPTION
This commit addresses the fact that regex and net/ssl were removed
from the Pony standard library. Since the http library depends on
these libraries we need to include them or the tests and examples
won't build.

The dependencies are added to a `bundle.json` file in the top level of
the project. This makes it available to all of the build targets
(test, bench, and examples).

Closes #23