### PR TITLE
Pin dependencies to specific version

### DIFF
--- a/bundle.json
+++ b/bundle.json
@@ -2,11 +2,13 @@
   "deps": [
     {
       "type": "github",
-      "repo": "ponylang/net-ssl"
+      "repo": "ponylang/net-ssl",
+      "tag": "1.0.0"
     },
     {
       "type": "github",
-      "repo": "ponylang/regex"
+      "repo": "ponylang/regex",
+      "tag": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
There is now an official release of the regex and net-ssl dependencies. This commit
pins to them.