### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is the Pony HTTP/1 library from the standard library, formerly known as `ne
 
 `http` was removed from the stdlib with [0.24.0](https://github.com/ponylang/ponyc/releases/tag/0.24.0) as a result of [RFC 55](https://github.com/ponylang/rfcs/blob/master/text/0055-remove-http-server-from-stdlib.md). See also [the announcement blog post](https://www.ponylang.io/blog/2018/06/0.24.0-released/).
 
-The Pony Team decided to remove it from the stdlib as is did not meet their quality standards. Given the familiarity of most people with HTTP and thus the attention this library gets, it was considered wiser to remove it from the stdlib and give it a new home as a separate package, where it will not be subject to RFCs in order to rework its innards.
+The Pony Team decided to remove it from the stdlib as it did not meet their quality standards. Given the familiarity of most people with HTTP and thus the attention this library gets, it was considered wiser to remove it from the stdlib and give it a new home as a separate package, where it will not be subject to RFCs in order to rework its innards.
 
 ### Help us improve
 


### PR DESCRIPTION
Change "is" to "it" in `README.md`.