### PR TITLE
Improve HTTP client send performance

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Announce
-        uses: ponylang/release-bot-action@0.4.0
+        uses: ponylang/release-bot-action@0.5.0
         with:
           step: announce-a-release
           git_user_name: "Ponylang Main Bot"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Trigger
-        uses: ponylang/release-bot-action@0.4.0
+        uses: ponylang/release-bot-action@0.5.0
         with:
           step: trigger-release-announcement
           git_user_name: "Ponylang Main Bot"

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Start
-        uses: ponylang/release-bot-action@0.4.0
+        uses: ponylang/release-bot-action@0.5.0
         with:
           step: start-a-release
           git_user_name: "Ponylang Main Bot"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 CHANGELOG.md
 CODE_OF_CONDUCT.md
+release-notes/

--- a/http/_client_connection.pony
+++ b/http/_client_connection.pony
@@ -52,6 +52,7 @@ actor _ClientConnection is HTTPSession
   var _safewait: Bool = false
   var _conn: (TCPConnection | None | _ConnConnecting) = None
   var _nobackpressure: Bool = true   // TCP backpressure indicator
+  embed _wr: Writer = Writer
 
   new create(
     auth: TCPConnectionAuth,
@@ -261,9 +262,8 @@ actor _ClientConnection is HTTPSession
           let request = _unsent.shift()?
           let safereq = request.is_safe()
           // Send all of the request that is possible for now.
-          let wr = recover ref Writer end
-          request._write(where wr = wr, keepalive = true)
-          conn.writev(wr.done())
+          request._write(where wr = _wr, keepalive = true)
+          conn.writev(_wr.done())
 
           // If there is a follow-on body, tell client to send it now.
           if request.has_body() then

--- a/http/_server_connection.pony
+++ b/http/_server_connection.pony
@@ -1,5 +1,6 @@
 use "net"
 use "collections"
+use "buffered"
 
 actor _ServerConnection is HTTPSession
   """
@@ -134,7 +135,9 @@ actor _ServerConnection is HTTPSession
     Send a single response.
     """
     let okstatus = (response.status < 300)
-    response._write(_keepalive and okstatus, _conn)
+    let wr = recover ref Writer end
+    response._write(_keepalive and okstatus, wr)
+    _conn.writev(wr.done())
 
     if response.has_body()
     then

--- a/http/_server_connection.pony
+++ b/http/_server_connection.pony
@@ -17,6 +17,7 @@ actor _ServerConnection is HTTPSession
   var _active_response: (Payload val | None) = None
   var _keepalive: Bool = true
   var _body_bytes_sent: USize = 0
+  embed _wr: Writer = Writer
 
   new create(
     handlermaker: HandlerFactory val,
@@ -135,9 +136,8 @@ actor _ServerConnection is HTTPSession
     Send a single response.
     """
     let okstatus = (response.status < 300)
-    let wr = recover ref Writer end
-    response._write(_keepalive and okstatus, wr)
-    _conn.writev(wr.done())
+    response._write(_keepalive and okstatus, _wr)
+    _conn.writev(_wr.done())
 
     if response.has_body()
     then


### PR DESCRIPTION
- Serialize the Payload using a `Writer` and then send a single
  message to the `TCPConnection`.

- This improves performance of the `HTTPClient` by factor 200 on my system.

- Before this change, I got 17 req/s. After the change it's 3333 req/s.