### PR TITLE
Update to match breaking API change in the pony standard library

### DIFF
--- a/.release-notes/63.md
+++ b/.release-notes/63.md
@@ -1,0 +1,3 @@
+## Forward prepare for coming breaking change in ponyc
+
+This change has no impact on end users, but will future proof against a coming breaking change in the standard library. Users of this version of the library won't be impacted by the coming change.

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -427,7 +427,7 @@ class iso _HTTPConnTest is UnitTest
           let loops: USize = 2
           // let service: String val = "12345"
           h.log("received service: [" + service + "]")
-          let us = "http://localhost:" + service
+          let us: String = "http://localhost:" + service
           h.log("URL: " + us)
           let url = URL.build(us)?
           h.log("url.string()=" + url.string())


### PR DESCRIPTION
This change is backwards compatible with ponyc 0.40.0