### PR TITLE
Make Payload headers case insensitive

### DIFF
--- a/.release-notes/case-insensitive.md
+++ b/.release-notes/case-insensitive.md
@@ -1,0 +1,5 @@
+## Make Payload headers case insensitive
+
+The HTTP spec says that headers are case-insensitve. That is, "Accept", "ACCEPT", "accept" etc are all the same thing. However, the http library was treating them as different headers.
+
+All headers are now converted to lowercase for storage in a Payload and all lookups are done using the key converted to lowercase.

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -718,7 +718,7 @@ class iso _HTTPParserStreamedBodyTest is UnitTest
 
 class _PayloadHeadersAreCaseInsensitive is UnitTest
   fun name(): String => "http/Payload.HeadersAreCaseInsensitive"
-  fun apply(h: TestHelper) ?=>
+  fun apply(h: TestHelper) ? =>
     let url = URL.valid("https://example.com")?
     let request = Payload.request(where url' = url)
     let some_caps_header: String = recover val "Accept" end
@@ -730,4 +730,3 @@ class _PayloadHeadersAreCaseInsensitive is UnitTest
 
     h.assert_eq[String](header_value, request(all_lower_header)?)
     h.assert_eq[String](header_value, request(all_upper_header)?)
-

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -37,6 +37,8 @@ actor Main is TestList
     test(_HTTPParserOneshotBodyTest)
     test(_HTTPParserStreamedBodyTest)
 
+    test(_PayloadHeadersAreCaseInsensitive)
+
 class iso _Encode is UnitTest
   fun name(): String => "http/URLEncode.encode"
 
@@ -713,3 +715,19 @@ class iso _HTTPParserStreamedBodyTest is UnitTest
     match parser.parse(reader)
     | ParseError => h.fail("parser failed to parse request.")
     end
+
+class _PayloadHeadersAreCaseInsensitive is UnitTest
+  fun name(): String => "http/Payload.HeadersAreCaseInsensitive"
+  fun apply(h: TestHelper) ?=>
+    let url = URL.valid("https://example.com")?
+    let request = Payload.request(where url' = url)
+    let some_caps_header: String = recover val "Accept" end
+    let all_lower_header: String = some_caps_header.lower()
+    let all_upper_header: String = some_caps_header.upper()
+    let header_value = "text/plain"
+
+    request(some_caps_header) = header_value
+
+    h.assert_eq[String](header_value, request(all_lower_header)?)
+    h.assert_eq[String](header_value, request(all_upper_header)?)
+

--- a/http/payload.pony
+++ b/http/payload.pony
@@ -165,7 +165,7 @@ class trn Payload
     """
     Get a header.
     """
-    _headers(key)?
+    _headers(key.lower())?
 
   fun is_safe(): Bool =>
     """
@@ -217,9 +217,10 @@ class trn Payload
     Set any header. If we've already received the header, append the value as a
     comma separated list, as per RFC 2616 section 4.2.
     """
-    match _headers(key) = value
+    let lk = recover val key.lower() end
+    match _headers(lk) = value
     | let prev: String =>
-      _headers(key) = prev + "," + value
+      _headers(lk) = prev + "," + value
     end
     this
 


### PR DESCRIPTION
The HTTP spec says that headers are case-insensitve. That is, "Accept",
"ACCEPT", "accept" etc are all the same thing. However, the http
library was treating them as different headers.

All headers are now converted to lowercase for storage in a Payload and
all lookups are done using the key converted to lowercase.

Closes #64