### PR TITLE
Update interfaces with private methods work with Pony 0.47.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.4.1:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.4.1:latest
     steps:
       - uses: actions/checkout@v2
       - name: Test
@@ -45,9 +45,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test against recent ponyc release on Windows
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command test 2>&1;

--- a/.release-notes/76.md
+++ b/.release-notes/76.md
@@ -1,0 +1,3 @@
+## Update interfaces with private methods work with Pony 0.47.0
+
+Interfaces can no longer have private methods. We've updated `HTTPSession` to match.

--- a/http/http_session.pony
+++ b/http/http_session.pony
@@ -1,4 +1,4 @@
-interface tag HTTPSession
+trait tag HTTPSession
   """
   An HTTP Session is the external API to the communication link
   between client and server. A session can only transfer one message
@@ -50,7 +50,7 @@ interface tag HTTPSession
     """
     The appropriate Payload Builder will call this from the `TCPConnection`
     actor to start delivery of a new *inbound* message. If the `Payload`s
-    `transfer_mode` is `OneshotTransfer`, this is the only notification 
+    `transfer_mode` is `OneshotTransfer`, this is the only notification
     that will happen for the message. Otherwise there will be one or more
     `_chunk` calls followed by a `_finish` call.
     """


### PR DESCRIPTION
Interfaces can no longer have private methods.