### PR TITLE
Add OpenSSL 3 support

### DIFF
--- a/.release-notes/openssl3.md
+++ b/.release-notes/openssl3.md
@@ -1,0 +1,3 @@
+## Add support for OpenSSL 3
+
+We've added support for working with OpenSSL 3 but updating to using `ponylang/net_ssl` 1.3.0 for SSL support.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
-  ifeq ($(ssl), 1.1.x)
+  ifeq ($(ssl), 3.0.x)
+	  SSL = -Dopenssl_3.0.x
+  else ifeq ($(ssl), 1.1.x)
 	  SSL = -Dopenssl_1.1.x
   else ifeq ($(ssl), 0.9.0)
 	  SSL = -Dopenssl_0.9.0

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/net_ssl.git",
-      "version": "1.2.1"
+      "version": "1.3.0"
     }
   ],
   "packages": [


### PR DESCRIPTION
The update to using net_ssl 1.3.0 brings with it support for working in environments where the SSL library uses the OpenSSL 3 API.