### PR TITLE
Upgrade OpenSSL 3.x test environment

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -51,7 +51,7 @@ jobs:
     name: OpenSSL 3.x with most recent ponyc latest
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3:latest
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0:latest
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
     name: OpenSSL 3.x with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.1.3:release
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-openssl_3.2.0:release
     steps:
       - uses: actions/checkout@v3
       - name: Test


### PR DESCRIPTION
This switches us to testing against OpenSSL 3.2.0 from OpenSSL 3.1.3.

3.1.3 seems to work fine for us, but we've identified a bug with OpenSSL 3.2.0. See https://github.com/ponylang/net_ssl/issues/105 for more information on the bug.