### PR TITLE
Change HTTPClient handler factory creation

### DIFF
--- a/.release-notes/106.md
+++ b/.release-notes/106.md
@@ -1,9 +1,6 @@
 ## Change HTTPClient handler factory creation
 
-The handler factory for creating handlers for new requests is now provided
-in the constructor of the client instead of the apply method. This
-makes it more clear, that the client will use the same handler for all
-requests.
+The handler factory for creating handlers for new requests is now provided in the constructor of the client instead of the apply method. This makes it more clear, that the client will use the same handler for all requests.
 
 The old version would look similar to this:
 

--- a/.release-notes/106.md
+++ b/.release-notes/106.md
@@ -16,8 +16,7 @@ client(payload, handler_factory)?
 client(other_payload, other_factory)
 ```
 
-In the new version the handler factory needs to be supplied at the
-creation of the client:
+In the new version the handler factory needs to be supplied at the creation of the client:
 
 ```pony
 let handler_factory = ...

--- a/.release-notes/106.md
+++ b/.release-notes/106.md
@@ -6,6 +6,7 @@ makes it more clear, that the client will use the same handler for all
 requests.
 
 The old version would look similar to this:
+
 ```pony
 let client = HTTPClient(auth)
 
@@ -15,8 +16,9 @@ let handler_factory = ...
 client(payload, handler_factory)?
 
 // Even later
-client(other_payload, ohter_factory)
+client(other_payload, other_factory)
 ```
+
 In the new version the handler factory needs to be supplied at the
 creation of the client:
 

--- a/.release-notes/106.md
+++ b/.release-notes/106.md
@@ -1,0 +1,36 @@
+## Change HTTPClient handler factory creation
+
+The handler factory for creating handlers for new requests is now provided
+in the constructor of the client instead of the apply method. This
+makes it more clear, that the client will use the same handler for all
+requests.
+
+The old version would look similar to this:
+```pony
+let client = HTTPClient(auth)
+
+// Later
+let handler_factory = ...
+
+client(payload, handler_factory)?
+
+// Even later
+client(other_payload, ohter_factory)
+```
+In the new version the handler factory needs to be supplied at the
+creation of the client:
+
+```pony
+let handler_factory = ...
+let client = HTTPClient(auth, handler_factory)
+
+client(payload)
+
+// This will use the handler_factory
+client(other_payload)
+
+// To use a different handler factory, create a new client
+
+let other_client = Client(auth, other_factory)
+other_client(other_payload)
+```

--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -90,12 +90,18 @@ actor _GetWork
       env.exitcode(1)
     end
 
-    // The Client manages all links.
-    let client = HTTPClient(TCPConnectAuth(env.root), consume sslctx where keepalive_timeout_secs = timeout.u32())
     // The Notify Factory will create HTTPHandlers as required.  It is
     // done this way because we do not know exactly when an HTTPSession
     // is created - they can be re-used.
     let dumpMaker = recover val NotifyFactory.create(this) end
+
+    // The Client manages all links.
+    let client = HTTPClient(
+      TCPConnectAuth(env.root),
+      dumpMaker,
+      consume sslctx
+      where keepalive_timeout_secs = timeout.u32()
+    )
 
     try
       // Start building a GET request.
@@ -119,7 +125,7 @@ actor _GetWork
       end
 
       // Submit the request
-      let sentreq = client(consume req, dumpMaker)?
+      let sentreq = client(consume req)?
 
       // Could send body data via `sentreq`, if it was a POST
     else

--- a/http/_test.pony
+++ b/http/_test.pony
@@ -435,13 +435,13 @@ class \nodoc\ iso _HTTPConnTest is UnitTest
           let url = URL.build(us)?
           h.log("url.string()=" + url.string())
           let hf = _HTTPConnTestHandlerFactory(h)
-          client = recover iso HTTPClient(TCPConnectAuth(h.env.root)) end
+          client = recover iso HTTPClient(TCPConnectAuth(h.env.root), hf) end
 
           for _ in Range(0, loops) do
             let payload: Payload iso = Payload.request("GET", url)
             payload.set_length(0)
             try
-              (client as HTTPClient iso)(consume payload, hf)?
+              (client as HTTPClient iso)(consume payload)?
             end
           end
         else

--- a/http/_test_client.pony
+++ b/http/_test_client.pony
@@ -58,16 +58,14 @@ class \nodoc\ iso _ClientStreamTransferTest is UnitTest
         try
           let client = HTTPClient(
             TCPConnectAuth(_h.env.root),
+            _StreamTransferHandlerFactory(_h),
             None
             where keepalive_timeout_secs = U32(2)
           )
           (let host, let port) = listen.local_address().name()?
           _h.log("connecting to server at " + host + ":" + port)
           let req = Payload.request("GET", URL.build("http://" + host + ":" + port  + "/bla")?)
-          client(
-            consume req,
-            _StreamTransferHandlerFactory(_h)
-          )?
+          client(consume req)?
         else
           _h.fail("request building failed")
         end

--- a/http/_test_client_error_handling.pony
+++ b/http/_test_client_error_handling.pony
@@ -53,6 +53,7 @@ class \nodoc\ iso _ConnectionClosedTest is UnitTest
         try
           let client = HTTPClient(
             TCPConnectAuth(_h.env.root),
+            _ConnectionClosedHandlerFactory(_h),
             None
             where keepalive_timeout_secs = U32(2)
           )
@@ -60,10 +61,7 @@ class \nodoc\ iso _ConnectionClosedTest is UnitTest
           let req = Payload.request("GET",
             URL.build("http://" + host + ":" + port  + "/bla")?)
           req.add_chunk("CHUNK")
-          client(
-            consume req,
-            _ConnectionClosedHandlerFactory(_h)
-          )?
+          client(consume req)?
         else
           _h.fail("request building failed")
         end
@@ -123,13 +121,14 @@ actor \nodoc\ _Connecter
     try
       let client = HTTPClient(
         TCPConnectAuth(_h.env.root),
+        _ConnectFailedHandlerFactory(_h),
         None
         where keepalive_timeout_secs = U32(2)
       )
       let req = Payload.request("GET",
         URL.build("http://" + host + ":" + port' + "/bla")?)
       req.add_chunk("CHUNK")
-      client(consume req, _ConnectFailedHandlerFactory(_h))?
+      client(consume req)?
     else
       _h.fail("request building failed")
     end
@@ -303,6 +302,7 @@ class \nodoc\ iso _SSLAuthFailedTest is UnitTest
             end
             let client = HTTPClient(
               TCPConnectAuth(_h.env.root),
+              _SSLAuthFailedHandlerFactory(_h),
               ssl_ctx
               where keepalive_timeout_secs = U32(2)
             )
@@ -310,10 +310,7 @@ class \nodoc\ iso _SSLAuthFailedTest is UnitTest
               "GET",
               URL.build("https://" + host + ":" + port  + "/bla")?)
             req.add_chunk("CHUNK")
-            client(
-              consume req,
-              _SSLAuthFailedHandlerFactory(_h)
-            )?
+            client(consume req)?
           else
             _h.fail("request building failed")
           end

--- a/http/test_netssl_105_regression.pony
+++ b/http/test_netssl_105_regression.pony
@@ -40,9 +40,9 @@ class \nodoc\ iso _NetSSL105RegressionTest is UnitTest
     try
       let url = URL.build("https://echo.sacovo.ch")?
       let auth = TCPConnectAuth(h.env.root)
-      let client = HTTPClient(auth)
+      let client = HTTPClient(auth, _NetSSL105RegressionHandlerFactory(h))
       let payload = Payload.request("GET", url)
-      client.apply(consume payload, _NetSSL105RegressionHandlerFactory(h))?
+      client.apply(consume payload)?
     else
       h.fail("Unable to setup test")
     end


### PR DESCRIPTION
The handler factory was supplied in the apply method of a client together with the Payload for the request. If the client already had a session for the new host, port and scheme, no new session was created and the supplied handler factory wasn't used.

The new design makes it clear, that one client uses the same handler factory for all requests it makes. If different handler factories are needed, different clients need to be created.