### PR TITLE
Link to the new http_server package for server related development

### DIFF
--- a/http/http.pony
+++ b/http/http.pony
@@ -1,6 +1,6 @@
 """
 This package includes all the support functions necessary to build client
-and server applications for the HTTP protocol.
+applications for the HTTP protocol.
 
 The important interfaces an application needs to deal with are:
 
@@ -18,7 +18,8 @@ message, with its headers.
 If you are writing a client, you will need to deal with the
 [HTTPClient](/http/http-HTTPClient/) class.
 
-If you are writing a server, you will need to deal with the
-[HTTPServer](/http/http-HTTPServer/) class.
+If you are writing a server, you should look at the
+[Server](https://ponylang.github.io/http_server/http_server-Server/)
+class in the [http_server](https://ponylang.github.io/http_server) package.
 
 """

--- a/http/payload.pony
+++ b/http/payload.pony
@@ -120,7 +120,7 @@ class trn Payload
   var username: String = ""
     """
     The username extracted from an `Authentication` header of an HTTP request
-    received via [HTTPServer](http-HTTPServer).
+    received via [HTTPServer](https://ponylang.github.io/http_server/http_server-Server/).
 
     This is not used and not sent using [HTTPClient](http-HTTPClient),
     use `update` to set an `Authentication` header instead.
@@ -128,7 +128,7 @@ class trn Payload
   var password: String = ""
     """
     The password extracted from an `Authentication` header of an HTTP request
-    received via [HTTPServer](http-HTTPServer).
+    received via [HTTPServer](https://ponylang.github.io/http_server/http_server-Server/).
 
     This is not used and not sent using [HTTPClient](http-HTTPClient),
     use `update` to set an `Authentication` header instead.


### PR DESCRIPTION
Functionality for implementing a server is provided in the new package but the documentation still referred to the HTTPServer class inside this package, which doesn't exist (anymore).