### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -12,6 +12,8 @@ jobs:
     name: Test against recent ponyc release on Windows
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test against recent ponyc release on Windows
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,8 @@ jobs:
     name: Windows x86-64 with most recent ponyc release
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test against recent ponyc release on Windows
         run: |
@@ -90,6 +92,8 @@ jobs:
     name: Windows arm64 with most recent ponyc release
     runs-on: windows-11-arm
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test against recent ponyc release on Windows
         run: |


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.