### PR TITLE
Deprecate in favor of ponylang/courier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,4 @@ Ponylang package to build clients for the HTTP protocol.
 
 ## Status
 
-`http` is beta quality software that will change frequently. Expect breaking changes. That said, you should feel comfortable using it in your projects.
-
-## Installation
-
-* Add `http` to your build dependencies using [corral](https://github.com/ponylang/corral):
-
-```bash
-corral add github.com/ponylang/http.git --version 0.6.4
-```
-
-* Execute `corral fetch` to fetch your dependencies.
-* Include this package by adding `use "http"` to your Pony sources.
-* Execute `corral run -- ponyc` to compile your application
-
-Note: The `ssl` transitive dependency requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl#installation) for more information.
-
-## API Documentation
-
-[https://ponylang.github.io/http](https://ponylang.github.io/http)
+Deprecated. Use [ponylang/courier](https://github.com/ponylang/courier) instead.


### PR DESCRIPTION
Development of this package is ceasing in favor of [ponylang/courier](https://github.com/ponylang/courier), the new HTTP client for Pony. This updates the README to point users there ahead of archiving the repository.

Scoped to the README only, matching the existing ponylang deprecation-notice convention (`net_ssl`, `json`).